### PR TITLE
fix(base): add new env variable registry to loki-stack

### DIFF
--- a/charts/base-cluster/Chart.yaml
+++ b/charts/base-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A generic, base cluster setup
 name: base-cluster
-version: 35.0.7
+version: 35.0.8
 home: "https://4allportal.com"
 maintainers:
   - name: tasches

--- a/charts/base-cluster/Chart.yaml
+++ b/charts/base-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A generic, base cluster setup
 name: base-cluster
-version: 35.0.10
+version: 35.0.11
 home: "https://4allportal.com"
 maintainers:
   - name: tasches

--- a/charts/base-cluster/README.md
+++ b/charts/base-cluster/README.md
@@ -1,6 +1,6 @@
 # base-cluster
 
-![Version: 35.0.10](https://img.shields.io/badge/Version-35.0.9-informational?style=flat-square)
+![Version: 35.0.10](https://img.shields.io/badge/Version-35.0.10-informational?style=flat-square)
 
 A generic, base cluster setup
 

--- a/charts/base-cluster/README.md
+++ b/charts/base-cluster/README.md
@@ -1,6 +1,6 @@
 # base-cluster
 
-![Version: 35.0.7](https://img.shields.io/badge/Version-35.0.7-informational?style=flat-square)
+![Version: 35.0.8](https://img.shields.io/badge/Version-35.0.8-informational?style=flat-square)
 
 A generic, base cluster setup
 

--- a/charts/base-cluster/templates/monitoring/loki-stack.yaml
+++ b/charts/base-cluster/templates/monitoring/loki-stack.yaml
@@ -59,7 +59,7 @@ spec:
     promtail:
       {{- if .Values.global.imageRegistry }}
       image:
-	registry: "{{ $.Values.global.imageRegistry }}/"
+	registry: "{{ $.Values.global.imageRegistry }}"
         repository: "grafana/promtail"
       {{- end }}
       resources: {{- .Values.monitoring.loki.promtail.resources | toYaml | nindent 8 }}

--- a/charts/base-cluster/templates/monitoring/loki-stack.yaml
+++ b/charts/base-cluster/templates/monitoring/loki-stack.yaml
@@ -59,7 +59,7 @@ spec:
     promtail:
       {{- if .Values.global.imageRegistry }}
       image:
-	registry: "{{ $.Values.global.imageRegistry }}"
+        registry: "{{ $.Values.global.imageRegistry }}"
         repository: "grafana/promtail"
       {{- end }}
       resources: {{- .Values.monitoring.loki.promtail.resources | toYaml | nindent 8 }}

--- a/charts/base-cluster/templates/monitoring/loki-stack.yaml
+++ b/charts/base-cluster/templates/monitoring/loki-stack.yaml
@@ -59,7 +59,8 @@ spec:
     promtail:
       {{- if .Values.global.imageRegistry }}
       image:
-        repository: "{{ $.Values.global.imageRegistry }}/grafana/promtail"
+	registry: "{{ $.Values.global.imageRegistry }}/"
+        repository: "grafana/promtail"
       {{- end }}
       resources: {{- .Values.monitoring.loki.promtail.resources | toYaml | nindent 8 }}
       {{- if .Values.monitoring.prometheus.enabled }}


### PR DESCRIPTION
Error in daemonset promtail. 
The image url is docker.io/<private registry>/grafana/promtail. It should either be docker.io/grafana/promtail or <private-registry>/grafana/promtail. 
This error occured because a default value was set in the subchart loki-stack.