### PR TITLE
fix(maxscale): fixing false release and fixing servicemonitors selector into object

### DIFF
--- a/charts/4allportal/Chart.lock
+++ b/charts/4allportal/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.4.0
 - name: maxscale
   repository: https://4allportal.github.io/helm-charts
-  version: 4.1.4
-digest: sha256:6d959ad082f1c7341f9cb02f4b5d1f278a16eab12dccea9869a327dd671fa315
-generated: "2023-05-26T14:35:07.179514614Z"
+  version: 4.1.5
+digest: sha256:f50f8c7b8a8db51589abe0aa30ff09b442eca74d006607faf5fcce466cd01433
+generated: "2023-06-13T11:38:05.280506795Z"

--- a/charts/4allportal/Chart.yaml
+++ b/charts/4allportal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.10.37"
 description: A Helm chart for 4ALLPORTAL version 3.10.0 and up
 name: 4allportal
-version: 19.0.43
+version: 19.0.44
 icon: https://4allportal.com/wp-content/uploads/2022/07/cropped-4ap_logo.png
 keywords:
   - 4ALLPORTAL
@@ -19,5 +19,5 @@ dependencies:
     version: 2.4.0
   - repository: https://4allportal.github.io/helm-charts
     name: maxscale
-    version: 4.1.4
+    version: 4.1.5
     condition: maxscale.enabled

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -1,6 +1,6 @@
 # 4allportal
 
-![Version: 19.0.43](https://img.shields.io/badge/Version-19.0.43-informational?style=flat-square) ![AppVersion: 3.10.37](https://img.shields.io/badge/AppVersion-3.10.37-informational?style=flat-square)
+![Version: 19.0.44](https://img.shields.io/badge/Version-19.0.44-informational?style=flat-square) ![AppVersion: 3.10.37](https://img.shields.io/badge/AppVersion-3.10.37-informational?style=flat-square)
 
 A Helm chart for 4ALLPORTAL version 3.10.0 and up
 
@@ -16,7 +16,7 @@ A Helm chart for 4ALLPORTAL version 3.10.0 and up
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://4allportal.github.io/helm-charts | maxscale | 4.1.4 |
+| https://4allportal.github.io/helm-charts | maxscale | 4.1.5 |
 | https://charts.bitnami.com/bitnami | common | 2.4.0 |
 
 ## Values

--- a/charts/maxscale/Chart.yaml
+++ b/charts/maxscale/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maxscale
 description: Deploys a maxscale mariadb-galera proxy including mariadb-galera
 type: application
-version: 4.1.5
+version: 4.1.6
 appVersion: 23.02.2
 maintainers:
   - name: tasches
@@ -14,5 +14,5 @@ dependencies:
     version: 2.4.0
   - repository: https://charts.bitnami.com/bitnami
     name: mariadb-galera
-    version: 7.5.5
+    version: 8.2.5
     alias: mariadb

--- a/charts/maxscale/README.md
+++ b/charts/maxscale/README.md
@@ -1,6 +1,6 @@
 # maxscale
 
-![Version: 4.1.5](https://img.shields.io/badge/Version-4.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 23.02.2](https://img.shields.io/badge/AppVersion-23.02.2-informational?style=flat-square)
+![Version: 4.1.6](https://img.shields.io/badge/Version-4.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 23.02.2](https://img.shields.io/badge/AppVersion-23.02.2-informational?style=flat-square)
 
 Deploys a maxscale mariadb-galera proxy including mariadb-galera
 
@@ -15,7 +15,7 @@ Deploys a maxscale mariadb-galera proxy including mariadb-galera
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | common | 2.4.0 |
-| https://charts.bitnami.com/bitnami | mariadb(mariadb-galera) | 7.5.5 |
+| https://charts.bitnami.com/bitnami | mariadb(mariadb-galera) | 8.2.5 |
 
 ## Values
 


### PR DESCRIPTION
I did a new branch with a reverted release, before im chaging again to the new 4.1.6. @tasches please review if this is the correct way.

Closes CL-57
https://jira.4allportal.net/browse/CL-57