### PR TITLE
feat(maxscale): make topologySpreadConstraints configurable

### DIFF
--- a/charts/maxscale/Chart.yaml
+++ b/charts/maxscale/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: maxscale
 description: Deploys a maxscale mariadb-galera proxy including mariadb-galera
 type: application
-version: 4.1.7
+version: 4.1.8
 appVersion: 23.02.2
 maintainers:
   - name: tasches

--- a/charts/maxscale/templates/deployment.yaml
+++ b/charts/maxscale/templates/deployment.yaml
@@ -24,12 +24,12 @@ spec:
       affinity:
         podAffinity: {{- include "common.affinities.pods.soft" (dict "component" "" "extraMatchLabels" (dict) "context" (dict "Release" .Release "Chart" (dict "Name" "mariadb") "Values" .Values.mariadb)) | nindent 10 }}
       topologySpreadConstraints:
-        - maxSkew: 1
+        - maxSkew: {{ .Values.topologySpreadConstraints.zone.maxSkew }}
           topologyKey: topology.kubernetes.io/zone
           whenUnsatisfiable: DoNotSchedule
           labelSelector:
             matchLabels: {{- include "common.labels.matchLabels" $ | nindent 14 }}
-        - maxSkew: 1
+        - maxSkew: {{ .Values.topologySpreadConstraints.node }}
           topologyKey: kubernetes.io/hostname
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:

--- a/charts/maxscale/values.schema.json
+++ b/charts/maxscale/values.schema.json
@@ -65,6 +65,37 @@
             }
           }
         },
+        "topologySpreadConstraints": {
+          "required": [
+            "zone",
+            "node"
+          ],
+          "type": "object",
+          "properties": {
+            "zone": {
+              "type": "object",
+              "required": [
+                "maxSkew"
+              ],
+              "properties": {
+                "maxSkew": {
+                  "type": "integer"
+                }
+              }
+            },
+            "node": {
+              "type": "object",
+              "required": [
+                "maxSkew"
+              ],
+              "properties": {
+                "maxSkew": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
         "mariadb": {
           "type": "object",
           "$ref": "https://raw.githubusercontent.com/bitnami/charts/master/bitnami/mariadb-galera/values.schema.json"

--- a/charts/maxscale/values.yaml
+++ b/charts/maxscale/values.yaml
@@ -20,6 +20,12 @@ image:
 replicas: 2
 enterpriseLicensed: false
 
+topologySpreadConstraints:
+  zone:
+    maxSkew: 1
+  node:
+    maxSkew: 1
+
 hpa:
   enabled: false
   minReplicas: 2


### PR DESCRIPTION
We have the problem that one of the control-plane nodes was scheduled in a different zone. Therefor two zones were found, but pods can only be scheduled in one zone.

So we have to change the maxSkew to allow for all pods to be scheduled.