### PR TITLE
fix(4allportal): ingress forwarding

### DIFF
--- a/charts/4allportal/Chart.yaml
+++ b/charts/4allportal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.10.38"
 description: A Helm chart for 4ALLPORTAL version 3.10.0 and up
 name: 4allportal
-version: 20.3.2
+version: 20.3.3
 icon: https://4allportal.com/wp-content/uploads/2022/07/cropped-4ap_logo.png
 keywords:
   - 4ALLPORTAL

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -1,6 +1,6 @@
 # 4allportal
 
-![Version: 20.3.2](https://img.shields.io/badge/Version-20.3.2-informational?style=flat-square) ![AppVersion: 3.10.38](https://img.shields.io/badge/AppVersion-3.10.38-informational?style=flat-square)
+![Version: 20.3.3](https://img.shields.io/badge/Version-20.3.3-informational?style=flat-square) ![AppVersion: 3.10.38](https://img.shields.io/badge/AppVersion-3.10.38-informational?style=flat-square)
 
 A Helm chart for 4ALLPORTAL version 3.10.0 and up
 
@@ -254,6 +254,7 @@ A Helm chart for 4ALLPORTAL version 3.10.0 and up
 | samba.resources.limits.memory | string | `"1Gi"` |  |
 | samba.resources.requests.cpu | string | `"10m"` |  |
 | samba.resources.requests.memory | string | `"32Mi"` |  |
+| samba.service.namespace | string | `""` |  |
 | samba.service.prefix | string | `""` |  |
 | samba.tolerations | list | `[]` |  |
 | samba.users | list | `[]` |  |

--- a/charts/4allportal/templates/4allportal/ingress.yaml
+++ b/charts/4allportal/templates/4allportal/ingress.yaml
@@ -31,10 +31,7 @@ spec:
 
           {{- if .Values.samba.enabled }}
           - path: "/smb"
-            backend:
-              service: {{ .Values.samba.service.prefix | default "portals" }}-samba-server.{{ .Values.samba.service.prefix | default "portals" }}
-              port:
-                name: ws
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-samba-server" (include "common.names.fullname" $)) "servicePort" "ws" "context" $) | nindent 14 }}
             pathType: Prefix
           {{- end }}
 

--- a/charts/4allportal/templates/samba/service.yaml
+++ b/charts/4allportal/templates/samba/service.yaml
@@ -28,5 +28,5 @@ spec:
   ports:
     - name: ws
       port: 80
-      targetPort: ws
+      targetPort: 80
 {{- end }}

--- a/charts/4allportal/templates/samba/service.yaml
+++ b/charts/4allportal/templates/samba/service.yaml
@@ -16,4 +16,17 @@ spec:
       targetPort: smb
   selector: {{- include "common.labels.matchLabels" $ | nindent 4 }}
     app.kubernetes.io/component: samba
-  {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ include "common.names.fullname" $ }}-samba-server"
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.samba.service.prefix | default "portals" }}-samba-server.{{ .Values.samba.service.namespace | default "portals" }}.svc.cluster.local
+  ports:
+    - name: ws
+      port: 80
+      targetPort: ws
+{{- end }}

--- a/charts/4allportal/values.yaml
+++ b/charts/4allportal/values.yaml
@@ -255,6 +255,7 @@ samba:
   mounts: []
   service:
     prefix: ""
+    namespace: ""
 
   livenessProbe:
     enabled: false


### PR DESCRIPTION
For obvious reasons which I didn't think about initially, Ingress forwarding doesn't work DNS based, instead requiring a Service and only a Service.

Ergo, ExternalName service with DNS entry is needed