### PR TITLE
fix(base-cluster): allow for traefik tag configuration

### DIFF
--- a/charts/base-cluster/Chart.yaml
+++ b/charts/base-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A generic, base cluster setup
 name: base-cluster
-version: 40.6.0
+version: 40.6.1
 home: "https://4allportal.com"
 maintainers:
   - name: jpkraemer-mg

--- a/charts/base-cluster/README.md
+++ b/charts/base-cluster/README.md
@@ -1,6 +1,6 @@
 # base-cluster
 
-![Version: 40.6.0](https://img.shields.io/badge/Version-40.6.0-informational?style=flat-square)
+![Version: 40.6.1](https://img.shields.io/badge/Version-40.6.1-informational?style=flat-square)
 
 A generic, base cluster setup
 
@@ -221,6 +221,7 @@ This helm chart requires flux v2 to be installed (https://fluxcd.io/docs/install
 | speedtest.image.tag | string | `"latest"` |  |
 | traefik.cipherSuites | list | `[]` |  |
 | traefik.debug.enabled | bool | `false` |  |
+| traefik.image.tag | string | `"3.3.4"` |  |
 | traefik.log.level | string | `"ERROR"` |  |
 | traefik.maxReplicas | int | `8` |  |
 | traefik.minReplicas | int | `2` |  |

--- a/charts/base-cluster/templates/ingress/traefik.yaml
+++ b/charts/base-cluster/templates/ingress/traefik.yaml
@@ -36,8 +36,9 @@ spec:
     remediation:
       retries: -1
   values:
-    {{- if .Values.global.imageRegistry }}
     image:
+      tag: {{ .Values.traefik.image.tag }}
+    {{- if .Values.global.imageRegistry }}
       registry: "{{ $.Values.global.imageRegistry }}"
     {{- end }}
     providers:

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -212,6 +212,15 @@
     "traefik": {
       "type": "object",
       "properties": {
+        "image": {
+          "type": "object",
+          "properties": {
+            "tag": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
         "resources": {
           "$ref": "https://kubernetesjsonschema.dev/v1.18.1/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements"
         },

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -63,7 +63,7 @@ flux:
 
 traefik:
   image:
-    tag: 3.3.4
+    tag: v3.3.4
   log:
     level: ERROR
   debug:

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -62,6 +62,8 @@ flux:
   resources: {}
 
 traefik:
+  image:
+    tag: 3.3.4
   log:
     level: ERROR
   debug:


### PR DESCRIPTION
set default to current released traefik version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable Traefik image tagging with a default value of 3.3.4 for enhanced deployment flexibility.
  
- **Documentation**
  - Updated the release version badge and configuration guidance to reflect the new image tag support.

- **Chores**
  - Bumped the Helm chart version from 40.6.0 to 40.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->