### PR TITLE
fix(4allportal): incorrect indentation in 4allportal deployment yaml

### DIFF
--- a/charts/4allportal/Chart.yaml
+++ b/charts/4allportal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.10.38"
 description: A Helm chart for 4ALLPORTAL version 3.10.0 and up
 name: 4allportal
-version: 20.8.0
+version: 20.8.1
 icon: https://4allportal.com/wp-content/uploads/2022/07/cropped-4ap_logo.png
 keywords:
   - 4ALLPORTAL

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -1,6 +1,6 @@
 # 4allportal
 
-![Version: 20.8.0](https://img.shields.io/badge/Version-20.8.0-informational?style=flat-square) ![AppVersion: 3.10.38](https://img.shields.io/badge/AppVersion-3.10.38-informational?style=flat-square)
+![Version: 20.8.1](https://img.shields.io/badge/Version-20.8.1-informational?style=flat-square) ![AppVersion: 3.10.38](https://img.shields.io/badge/AppVersion-3.10.38-informational?style=flat-square)
 
 A Helm chart for 4ALLPORTAL version 3.10.0 and up
 

--- a/charts/4allportal/templates/4allportal/deployment.yaml
+++ b/charts/4allportal/templates/4allportal/deployment.yaml
@@ -230,13 +230,13 @@ spec:
             {{- if not (regexMatch "(DERIVATESERVICE(_DEBUG)?_JAVA_OPTIONS|JAVA_OPTS)" $name) }}
             - name: {{ $name }}
               value: {{ $value | quote }}
-            {{- end }}
-            {{- end }}
+          {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8181
               protocol: TCP
-            {{- if .Values.fourAllPortal.debug }}
+          {{- if .Values.fourAllPortal.debug }}
             - name: debug
               containerPort: 8001
               protocol: TCP


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Helm chart version and version badge from 20.8.0 to 20.8.1.

- **Style**
	- Corrected indentation in deployment template files to improve formatting and ensure proper rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->