### PR TITLE
fix(4allportal): revert protect prometheus endpoint

### DIFF
--- a/charts/4allportal/Chart.yaml
+++ b/charts/4allportal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.10.38"
 description: A Helm chart for 4ALLPORTAL version 3.10.0 and up
 name: 4allportal
-version: 20.8.2
+version: 20.8.3
 icon: https://4allportal.com/wp-content/uploads/2022/07/cropped-4ap_logo.png
 keywords:
   - 4ALLPORTAL

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -1,6 +1,6 @@
 # 4allportal
 
-![Version: 20.8.2](https://img.shields.io/badge/Version-20.8.2-informational?style=flat-square) ![AppVersion: 3.10.38](https://img.shields.io/badge/AppVersion-3.10.38-informational?style=flat-square)
+![Version: 20.8.3](https://img.shields.io/badge/Version-20.8.3-informational?style=flat-square) ![AppVersion: 3.10.38](https://img.shields.io/badge/AppVersion-3.10.38-informational?style=flat-square)
 
 A Helm chart for 4ALLPORTAL version 3.10.0 and up
 

--- a/charts/4allportal/templates/4allportal/deployment.yaml
+++ b/charts/4allportal/templates/4allportal/deployment.yaml
@@ -217,23 +217,11 @@ spec:
 
             {{- include "4allportal.tracing.jaeger.env" (dict "Chart" .Chart "Release" .Release "Values" .Values "local" .Values.fourAllPortal.tracing) | nindent 12 }}
 
-            - name: DERIVATESERVICE_JAVA_OPTIONS
-              value: {{ trim (printf "%s %s" "-Dmanagement.server.port=9001" (trimPrefix " " (include "fourAllPortal.env.derivateOpts" . ))) | quote }}
-
-            - name: DERIVATESERVICE_DEBUG_JAVA_OPTIONS
-              value: {{ trim (printf "%s %s" "-Dmanagement.server.port=9001" (trimPrefix " " (include "fourAllPortal.env.derivateDebugOpts" . ))) | quote }}
-
-            - name: JAVA_OPTS
-              value: {{ trim (printf "%s %s" "-Dmanagement.server.port=9000" (trimPrefix " " (include "fourAllPortal.env.javaOpts" . ))) | quote }}
-
             {{- range $name, $value := .Values.fourAllPortal.env }}
-            {{- if not (regexMatch "(DERIVATESERVICE(_DEBUG)?_JAVA_OPTIONS|JAVA_OPTS)" $name) }}
             - name: {{ $name }}
               value: {{ $value | quote }}
           {{- end }}
-          {{- end }}
           ports:
-          {{- if .Values.fourAllPortal }}
             - name: http
               containerPort: 8181
               protocol: TCP
@@ -244,9 +232,8 @@ spec:
             {{- end }}
             {{- if .Values.fourAllPortal.metrics.enabled }}
             - name: metrics
-              containerPort: 9000
+              containerPort: 8181
               protocol: TCP
-            {{- end }}
           {{- end }}
           {{- if and (not .Values.fourAllPortal.debug) .Values.fourAllPortal.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/4allportal/templates/4allportal/service.yaml
+++ b/charts/4allportal/templates/4allportal/service.yaml
@@ -18,7 +18,7 @@ spec:
       name: debug
     {{- end }}
     {{- if .Values.fourAllPortal.metrics.enabled }}
-    - port: 9000
+    - port: 8181
       targetPort: metrics
       protocol: TCP
       name: metrics

--- a/charts/4allportal/templates/_helpers.tpl
+++ b/charts/4allportal/templates/_helpers.tpl
@@ -79,30 +79,6 @@ mariadb
 {{- end -}}
 {{- end -}}
 
-{{- define "fourAllPortal.env.javaOpts" -}}
-{{- range $name, $value := .Values.fourAllPortal.env -}}
-{{- if eq "JAVA_OPTS" $name -}}
-{{ $value }}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "fourAllPortal.env.derivateOpts" -}}
-{{- range $name, $value := .Values.fourAllPortal.env -}}
-{{- if eq "DERIVATESERVICE_JAVA_OPTIONS" $name -}}
-{{ $value }}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "fourAllPortal.env.derivateDebugOpts" -}}
-{{- range $name, $value := .Values.fourAllPortal.env -}}
-{{- if eq "DERIVATESERVICE_DEBUG_JAVA_OPTIONS" $name -}}
-{{ $value }}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
 {{/*
 Helper functions for secret references instead of clear text references for data
 */}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the metrics service port from 9000 to 8181 for improved alignment and consistency.
  - Removed explicit Java-related environment variables from the deployment configuration to simplify environment management.

- **Chores**
  - Incremented the Helm chart version to 20.8.3 and updated the version badge in documentation.
  - Cleaned up redundant helper functions and conditional blocks in Helm templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->