### PR TITLE
fix(base-cluster): remove static namespace flux

### DIFF
--- a/charts/base-cluster/Chart.yaml
+++ b/charts/base-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A generic, base cluster setup
 name: base-cluster
-version: 40.6.3
+version: 40.6.4
 home: "https://4allportal.com"
 maintainers:
   - name: jpkraemer-mg

--- a/charts/base-cluster/README.md
+++ b/charts/base-cluster/README.md
@@ -1,6 +1,6 @@
 # base-cluster
 
-![Version: 40.6.3](https://img.shields.io/badge/Version-40.6.3-informational?style=flat-square)
+![Version: 40.6.4](https://img.shields.io/badge/Version-40.6.4-informational?style=flat-square)
 
 A generic, base cluster setup
 

--- a/charts/base-cluster/templates/flux/flux.yaml
+++ b/charts/base-cluster/templates/flux/flux.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: flux-{{- $name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: {{ $name | quote }}
     app.kubernetes.io/part-of: flux
@@ -16,7 +16,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: flux-{{- $name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: {{ $name | quote }}
     app.kubernetes.io/part-of: flux
@@ -30,7 +30,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: flux-{{- $name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: flux
 spec:
@@ -39,5 +39,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-{{- $name }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ $.Release.Namespace }}
 {{- end }}

--- a/charts/base-cluster/templates/flux/flux.yaml
+++ b/charts/base-cluster/templates/flux/flux.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: flux-{{- $name }}
-  namespace: flux
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: {{ $name | quote }}
     app.kubernetes.io/part-of: flux
@@ -16,7 +16,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: GitRepository
 metadata:
   name: flux-{{- $name }}
-  namespace: flux
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: {{ $name | quote }}
     app.kubernetes.io/part-of: flux
@@ -30,7 +30,7 @@ apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
 metadata:
   name: flux-{{- $name }}
-  namespace: flux
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "common.labels.standard" $ | nindent 4 }}
     app.kubernetes.io/component: flux
 spec:
@@ -39,5 +39,5 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-{{- $name }}
-    namespace: flux
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/base-cluster/templates/sealedsecrets/helmrepo.yaml
+++ b/charts/base-cluster/templates/sealedsecrets/helmrepo.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: sealed-secrets
-  namespace: flux
+  namespace: {{ .Release.Namespace }}
 spec:
   interval: 1m
   url: https://bitnami-labs.github.io/sealed-secrets

--- a/charts/base-cluster/templates/sealedsecrets/sealed-secrets-controller.yaml
+++ b/charts/base-cluster/templates/sealedsecrets/sealed-secrets-controller.yaml
@@ -3,7 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: sealed-secrets
-  namespace: flux
+  namespace: {{ .Release.Namespace }}
 spec:
   chart:
     spec:
@@ -14,7 +14,7 @@ spec:
       version: ">=1.15.0-0"
   interval: 1h0m0s
   releaseName: sealed-secrets-controller
-  targetNamespace: flux
+  targetNamespace: {{ .Release.Namespace }}
   install:
     crds: Create
   upgrade:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Helm chart resources now deploy to the namespace where the Helm release is installed, instead of a fixed namespace.
- **Documentation**
  - Updated version badge in the README to reflect the new chart version.
- **Chores**
  - Incremented Helm chart version to 40.6.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->