### PR TITLE
fix(base-cluster): ingress monitor operator checking wrong value

### DIFF
--- a/charts/base-cluster/Chart.yaml
+++ b/charts/base-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A generic, base cluster setup
 name: base-cluster
-version: 41.0.8
+version: 41.0.9
 home: "https://4allportal.com"
 maintainers:
   - name: jpkraemer-mg

--- a/charts/base-cluster/README.md
+++ b/charts/base-cluster/README.md
@@ -393,5 +393,4 @@ Credentials must now be specified as existing secrets to avoid plaintext passwor
 | monitoring.prometheus.alertmanager.pagerduty. | monitoring.prometheus.alertmanager.pagerduty.existingRoutingKeySecret | pagerduty_routing_key | Secret must contain pagerduty_routing_key |
 | monitoring.grafana.* | monitoring.grafana.envFromSecrets | * | A list of secret keys to be used in envFromSecret |
 | monitoring.grafana.* | monitoring.grafana.existingAdminSecret | admin-user, admin-password | Secret must contain admin-user, admin-password |
-| monitoring.ingress.* | monitoring.ingress.existingSecret | * | Secret with the enableMonitorDeletion, creationDelay and providers |
 | monitoring.ingress.* | monitoring.ingress.existingConfigSecret | * | Secret with the enableMonitorDeletion, creationDelay and providers |

--- a/charts/base-cluster/README.md.gotmpl
+++ b/charts/base-cluster/README.md.gotmpl
@@ -183,5 +183,4 @@ Credentials must now be specified as existing secrets to avoid plaintext passwor
 | monitoring.prometheus.alertmanager.pagerduty. | monitoring.prometheus.alertmanager.pagerduty.existingRoutingKeySecret | pagerduty_routing_key | Secret must contain pagerduty_routing_key |
 | monitoring.grafana.* | monitoring.grafana.envFromSecrets | * | A list of secret keys to be used in envFromSecret |
 | monitoring.grafana.* | monitoring.grafana.existingAdminSecret | admin-user, admin-password | Secret must contain admin-user, admin-password |
-| monitoring.ingress.* | monitoring.ingress.existingSecret | * | Secret with the enableMonitorDeletion, creationDelay and providers |
 | monitoring.ingress.* | monitoring.ingress.existingConfigSecret | * | Secret with the enableMonitorDeletion, creationDelay and providers |

--- a/charts/base-cluster/templates/monitoring/ingress/operator.yaml
+++ b/charts/base-cluster/templates/monitoring/ingress/operator.yaml
@@ -32,7 +32,7 @@ spec:
     serviceMonitor:
       enabled: true
     {{- end }}
-    configSecretName: {{ required "You must provide a secret for ingress monitor operator" .Values.monitoring.ingress.existingSecret }}
+    configSecretName: {{ required "You must provide a secret for ingress monitor operator" .Values.monitoring.ingress.existingConfigSecret }}
     podAnnotations:
       checksum/secret: {{ include (print $.Template.BasePath "/monitoring/ingress/operator-secret.yaml") . | sha256sum }}
   {{- end -}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed configuration value monitoring.ingress.existingSecret to monitoring.ingress.existingConfigSecret for ingress monitoring. Update your values accordingly.
* **Documentation**
  * Updated README to reflect the new configuration key and refreshed the version badge.
  * Removed outdated reference to the previous secret key.
* **Chores**
  * Bumped Helm chart version to 41.0.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->