### PR TITLE
feat(base-cluster): exclude kube janitor resources

### DIFF
--- a/charts/base-cluster/Chart.yaml
+++ b/charts/base-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A generic, base cluster setup
 name: base-cluster
-version: 41.2.5
+version: 41.2.6
 home: "https://4allportal.com"
 maintainers:
   - name: jpkraemer-mg

--- a/charts/base-cluster/README.md
+++ b/charts/base-cluster/README.md
@@ -1,6 +1,6 @@
 # base-cluster
 
-![Version: 41.2.5](https://img.shields.io/badge/Version-41.2.5-informational?style=flat-square)
+![Version: 41.2.6](https://img.shields.io/badge/Version-41.2.6-informational?style=flat-square)
 
 A generic, base cluster setup
 
@@ -101,6 +101,9 @@ This helm chart requires flux v2 to be installed (https://fluxcd.io/docs/install
 | global.priorityClasses.defaultClasses.very-high.preemptionPolicy | string | `"PreemptLowerPriority"` |  |
 | global.priorityClasses.defaultClasses.very-high.value | int | `10000` |  |
 | janitor.enabled | bool | `true` |  |
+| janitor.excludeNamespaces[0] | string | `"kube-system"` |  |
+| janitor.excludeResources[0] | string | `"events"` |  |
+| janitor.excludeResources[1] | string | `"controllerrevisions"` |  |
 | monitoring.costAnalysis.currency | string | `"currencyEUR"` |  |
 | monitoring.costAnalysis.storageClassMapping | object | `{}` |  |
 | monitoring.deadMansSnitch.enabled | bool | `false` |  |
@@ -417,7 +420,3 @@ Allow additional arguments to be passed to traefik
 ## To 41.2.3
 
 We've enabled the external-dns deployment's Traefik source for use in DNS management.
-
-## To 41.2.6
-
-Made kube janitor namespaces/resources excludable.

--- a/charts/base-cluster/README.md
+++ b/charts/base-cluster/README.md
@@ -417,3 +417,7 @@ Allow additional arguments to be passed to traefik
 ## To 41.2.3
 
 We've enabled the external-dns deployment's Traefik source for use in DNS management.
+
+## To 41.2.6
+
+Made kube janitor namespaces/resources excludable.

--- a/charts/base-cluster/templates/global/janitor.yaml
+++ b/charts/base-cluster/templates/global/janitor.yaml
@@ -43,4 +43,7 @@ spec:
     resources:
       limits:
         memory: 1Gi
+    kubejanitor:
+      excludeResources: {{ .Values.janitor.excludeResources | toJson }}
+      excludeNamespaces: {{ .Values.janitor.excludeNamespaces | toJson }}
   {{- end -}}

--- a/charts/base-cluster/values.schema.json
+++ b/charts/base-cluster/values.schema.json
@@ -306,6 +306,18 @@
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "excludeResources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excludeNamespaces": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/charts/base-cluster/values.yaml
+++ b/charts/base-cluster/values.yaml
@@ -90,6 +90,11 @@ sealedsecrets:
 
 janitor:
   enabled: true
+  excludeResources:
+    - events
+    - controllerrevisions
+  excludeNamespaces:
+    - kube-system
 
 monitoring:
   ingress:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options to exclude specific resources and namespaces from janitor cleanup operations, with default exclusions for events, controllerrevisions, and kube-system namespace

* **Chores**
  * Bumped Helm chart version to 41.2.6

* **Documentation**
  * Updated documentation with janitor exclusion configuration options and defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->