### PR TITLE
fix(4allportal): rename db type mssql to sqlserver

### DIFF
--- a/charts/4allportal/Chart.yaml
+++ b/charts/4allportal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.10.62"
 description: A Helm chart for 4ALLPORTAL version 3.10.0 and up
 name: 4allportal
-version: 22.0.0
+version: 22.0.1
 icon: https://4allportal.com/wp-content/uploads/2022/07/cropped-4ap_logo.png
 keywords:
   - 4ALLPORTAL

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -1,6 +1,6 @@
 # 4allportal
 
-![Version: 22.0.0](https://img.shields.io/badge/Version-22.0.0-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
+![Version: 22.0.1](https://img.shields.io/badge/Version-22.0.1-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
 
 A Helm chart for 4ALLPORTAL version 3.10.0 and up
 
@@ -374,3 +374,21 @@ The following fields are now **optional**:
 - `.Values.fourAllPortal.database.operator.password`
 
 If these values are not set, the operator will **automatically generate them** and store the data in a **new Kubernetes Secret**, which is then used by 4allportal.
+
+## To 22.0.1
+
+This release renames the database type `mssql` to `sqlserver` to align with the correct naming convention.
+
+The value `mssql` introduced in 20.12.0 is now **deprecated** but continues to work as an alias for `sqlserver`. Support for `mssql` will be removed in a future major release.
+
+### Recommended Action
+
+Update your values from:
+
+`.Values.fourAllPortal.database.existing.type: mssql`
+
+to:
+
+`.Values.fourAllPortal.database.existing.type: sqlserver`
+
+No other changes to the database configuration are required.

--- a/charts/4allportal/README.md.gotmpl
+++ b/charts/4allportal/README.md.gotmpl
@@ -103,3 +103,21 @@ The following fields are now **optional**:
 - `.Values.fourAllPortal.database.operator.password`
 
 If these values are not set, the operator will **automatically generate them** and store the data in a **new Kubernetes Secret**, which is then used by 4allportal.
+
+## To 22.0.1
+
+This release renames the database type `mssql` to `sqlserver` to align with the correct naming convention.
+
+The value `mssql` introduced in 20.12.0 is now **deprecated** but continues to work as an alias for `sqlserver`. Support for `mssql` will be removed in a future major release.
+
+### Recommended Action
+
+Update your values from:
+
+`.Values.fourAllPortal.database.existing.type: mssql`
+
+to:
+
+`.Values.fourAllPortal.database.existing.type: sqlserver`
+
+No other changes to the database configuration are required.

--- a/charts/4allportal/templates/4allportal/deployment.yaml
+++ b/charts/4allportal/templates/4allportal/deployment.yaml
@@ -142,9 +142,12 @@ spec:
               value: {{ .Values.fourAllPortal.mail.security | quote }}
             {{- end }}
 
-            {{- if eq (default "" .Values.fourAllPortal.database.existing.type) "mssql" }}
+            {{- if or (eq (default "" .Values.fourAllPortal.database.existing.type) "mssql") (eq (default "" .Values.fourAllPortal.database.existing.type) "sqlserver") }}
+              {{- if eq (default "" .Values.fourAllPortal.database.existing.type) "mssql" }}
+            # WARNING: database.existing.type 'mssql' is deprecated, use 'sqlserver' instead. Support for 'mssql' will be removed in a future release.
+              {{- end }}
             - name: DATABASE_TYPE
-              value: {{ .Values.fourAllPortal.database.existing.type }}
+              value: "sqlserver"
             - name: DATABASE_JDBC_URL
               value: {{ include "4allportal.fourallportal.database.jdbcUrl" . }}
             - name: DATABASE_USER

--- a/charts/4allportal/values.schema.json
+++ b/charts/4allportal/values.schema.json
@@ -1060,11 +1060,11 @@
                   "type": "integer"
                 },
                 "type": {
-                  "type": "string",
-                  "enum": [
-                    "mysql",
-                    "mariadb",
-                    "mssql"
+                  "oneOf": [
+                    { "const": "mysql" },
+                    { "const": "mariadb" },
+                    { "const": "sqlserver" },
+                    { "const": "mssql", "deprecated": true }
                   ]
                 },
                 "user": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 22.0.1 with database configuration improvements.

* **Documentation**
  * Added upgrade guide for database type configuration change.
  * Database type option renamed from `mssql` to `sqlserver`.
  * `mssql` remains supported as a deprecated alias for backward compatibility.
  * Users are recommended to update their configuration to use `sqlserver`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->