### PR TITLE
fix(4allportal): add api.4allportal.cloud egress and fix matchPattern…

### DIFF
--- a/charts/4allportal/Chart.yaml
+++ b/charts/4allportal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.10.62"
 description: A Helm chart for 4ALLPORTAL version 3.10.0 and up
 name: 4allportal
-version: 22.0.1
+version: 22.0.2
 icon: https://4allportal.com/wp-content/uploads/2022/07/cropped-4ap_logo.png
 keywords:
   - 4ALLPORTAL

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -1,6 +1,6 @@
 # 4allportal
 
-![Version: 22.0.1](https://img.shields.io/badge/Version-22.0.1-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
+![Version: 22.0.2](https://img.shields.io/badge/Version-22.0.2-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
 
 A Helm chart for 4ALLPORTAL version 3.10.0 and up
 
@@ -392,3 +392,9 @@ to:
 `.Values.fourAllPortal.database.existing.type: sqlserver`
 
 No other changes to the database configuration are required.
+
+## To 22.0.2
+
+This release adds an egress rule for `api.4allportal.cloud` on port 443 to the Cilium network policy.
+
+No action required.

--- a/charts/4allportal/README.md.gotmpl
+++ b/charts/4allportal/README.md.gotmpl
@@ -121,3 +121,9 @@ to:
 `.Values.fourAllPortal.database.existing.type: sqlserver`
 
 No other changes to the database configuration are required.
+
+## To 22.0.2
+
+This release adds an egress rule for `api.4allportal.cloud` on port 443 to the Cilium network policy.
+
+No action required.

--- a/charts/4allportal/templates/4allportal/ciliumNetworkPolicy.yaml
+++ b/charts/4allportal/templates/4allportal/ciliumNetworkPolicy.yaml
@@ -50,7 +50,8 @@ spec:
     {{- end }}
     {{- end }}
     - toFQDNs:
-        - matchPattern: "repository.4allportal.net"
+        - matchName: "repository.4allportal.net"
+        - matchName: "api.4allportal.cloud"
       toPorts:
         - ports:
             - port: "443"


### PR DESCRIPTION
## Summary

- Add egress rule for `api.4allportal.cloud` on port 443 to the 4allportal backend `CiliumNetworkPolicy`
- Fix `repository.4allportal.net` from `matchPattern` to `matchName` — no wildcard was used, making `matchPattern` incorrect

## Test plan

- [ ] Verify Helm template renders correctly with both FQDN entries under the port 443 egress rule
- [ ] Confirm outbound HTTPS traffic to `api.4allportal.cloud` is allowed after deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network connectivity configuration to enable communication with an additional service endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/4ALLPORTAL/helm-charts/pull/382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->