### PR TITLE
feat(4allportal): skip secret creation when backup secret name is set

### DIFF
--- a/charts/4allportal/Chart.yaml
+++ b/charts/4allportal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.10.62"
 description: A Helm chart for 4ALLPORTAL version 3.10.0 and up
 name: 4allportal
-version: 22.0.2
+version: 22.0.3
 icon: https://4allportal.com/wp-content/uploads/2022/07/cropped-4ap_logo.png
 keywords:
   - 4ALLPORTAL

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -1,6 +1,6 @@
 # 4allportal
 
-![Version: 22.0.2](https://img.shields.io/badge/Version-22.0.2-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
+![Version: 22.0.3](https://img.shields.io/badge/Version-22.0.3-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
 
 A Helm chart for 4ALLPORTAL version 3.10.0 and up
 
@@ -398,3 +398,11 @@ No other changes to the database configuration are required.
 This release adds an egress rule for `api.4allportal.cloud` on port 443 to the Cilium network policy.
 
 No action required.
+
+## To 22.0.3
+
+This release adds support for referencing an external secret for backup credentials instead of providing plain-text values.
+
+When `.Values.backups.volumes.secretName` is set, the chart no longer creates an internal secret from the plain-text values `.Values.backups.volumes.password`, `.Values.backups.target.s3.accessKey`, and `.Values.backups.target.s3.secretKey`. The referenced secret must contain the keys `RESTIC_PASSWORD`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+
+No action required if you are not using `.Values.backups.volumes.secretName`.

--- a/charts/4allportal/README.md.gotmpl
+++ b/charts/4allportal/README.md.gotmpl
@@ -127,3 +127,11 @@ No other changes to the database configuration are required.
 This release adds an egress rule for `api.4allportal.cloud` on port 443 to the Cilium network policy.
 
 No action required.
+
+## To 22.0.3
+
+This release adds support for referencing an external secret for backup credentials instead of providing plain-text values.
+
+When `.Values.backups.volumes.secretName` is set, the chart no longer creates an internal secret from the plain-text values `.Values.backups.volumes.password`, `.Values.backups.target.s3.accessKey`, and `.Values.backups.target.s3.secretKey`. The referenced secret must contain the keys `RESTIC_PASSWORD`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+
+No action required if you are not using `.Values.backups.volumes.secretName`.

--- a/charts/4allportal/templates/backup/volumes/secret.yaml
+++ b/charts/4allportal/templates/backup/volumes/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (or $.Values.global.persistence.enabled $.Values.fourAllPortal.persistence.assets.enabled) .Values.backups.volumes.enabled -}}
+{{- if and (or $.Values.global.persistence.enabled $.Values.fourAllPortal.persistence.assets.enabled) .Values.backups.volumes.enabled (eq .Values.backups.volumes.secretName "") -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/4allportal/templates/validation.tpl
+++ b/charts/4allportal/templates/validation.tpl
@@ -27,7 +27,9 @@
 {{- end -}}
 
 {{- if eq .Values.samba.enabled true -}}
+{{- if and (eq .Values.samba.secret.name "") (eq .Values.samba.secret.key "") -}}
 {{- if eq .Values.samba.adminPassword "CHANGEME" -}}
 {{- fail "You need to change samba.adminPassword" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for external Kubernetes secrets to manage backup credentials, eliminating the need for plain-text configuration values.

* **Documentation**
  * Updated upgrade guidance for the 4allportal chart, including migration path to version 22.0.3.
  * Added comprehensive documentation for the base-cluster-v2 Helm chart, including configuration options and bootstrapped infrastructure components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/4ALLPORTAL/helm-charts/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->