### PR TITLE
fix(base-cluster-v2): coderabbit followup

### DIFF
--- a/charts/base-cluster-v2/Chart.yaml
+++ b/charts/base-cluster-v2/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   cert-manager, ExternalDNS, and an internal Librespeed speedtest endpoint.
   Successor to the base-cluster chart.
 type: application
-version: 1.0.2
+version: 1.0.3
 appVersion: "1.0.2"
 home: https://4allportal.com
 maintainers:

--- a/charts/base-cluster-v2/README.md
+++ b/charts/base-cluster-v2/README.md
@@ -1,6 +1,6 @@
 # base-cluster-v2
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.2](https://img.shields.io/badge/AppVersion-1.0.2-informational?style=flat-square)
+![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.2](https://img.shields.io/badge/AppVersion-1.0.2-informational?style=flat-square)
 
 Foundational base cluster setup — Cilium CNI, FluxCD, Traefik ingress,
 cert-manager, ExternalDNS, and an internal Librespeed speedtest endpoint.

--- a/charts/base-cluster-v2/templates/cert-manager/clusterissuer.yaml
+++ b/charts/base-cluster-v2/templates/cert-manager/clusterissuer.yaml
@@ -1,7 +1,11 @@
 {{/*
-Let's Encrypt production ClusterIssuer with two solvers:
-  - DNS01 via Cloudflare for wildcards (used by the cluster wildcard cert)
-  - HTTP01 via the default ingress for everything else
+Let's Encrypt production ClusterIssuer.
+  - DNS01 via Cloudflare: scoped to `.Values.dns.domains` when set, otherwise a
+    catch-all that handles every order (required for the cluster wildcard cert).
+  - HTTP01 via the default ingress: only rendered when `.Values.dns.domains` is
+    set, where it is the catch-all fallback for zones outside the DNS01 scope.
+    When `dns.domains` is empty ("all" via DNS01) it is omitted so the two
+    solvers don't both become catch-alls (cert-manager picks ambiguously then).
 
 Requires a Secret named `.Values.dns.existingSecret` in the chart namespace
 with key `cloudflare_api_token`. The cert-manager chart's CRDs ship with this
@@ -29,5 +33,7 @@ spec:
         selector:
           dnsZones: {{- . | toYaml | nindent 12 }}
         {{- end }}
+      {{- if .Values.dns.domains }}
       - http01:
           ingress: {}
+      {{- end }}

--- a/charts/base-cluster-v2/templates/cilium/cilium.yaml
+++ b/charts/base-cluster-v2/templates/cilium/cilium.yaml
@@ -41,7 +41,7 @@ spec:
   values:
     MTU: {{ .Values.cilium.mtu }}
     {{- with .Values.cilium.devices }}
-    devices: {{ . }}
+    devices: {{- toYaml . | nindent 6 }}
     {{- end }}
     cni:
       install: true

--- a/charts/base-cluster-v2/templates/flux/cilium-network-policy.yaml
+++ b/charts/base-cluster-v2/templates/flux/cilium-network-policy.yaml
@@ -8,7 +8,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: flux-controllers
-  namespace: {{ .Release.Namespace }}
+  namespace: flux-system
   labels: {{- include "base-cluster.labels" . | nindent 4 }}
     app.kubernetes.io/component: flux
 spec:
@@ -46,7 +46,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: flux-notification-webhook
-  namespace: {{ .Release.Namespace }}
+  namespace: flux-system
   labels: {{- include "base-cluster.labels" . | nindent 4 }}
     app.kubernetes.io/component: flux
 spec:

--- a/charts/base-cluster-v2/templates/flux/cilium-network-policy.yaml
+++ b/charts/base-cluster-v2/templates/flux/cilium-network-policy.yaml
@@ -30,6 +30,8 @@ spec:
         - ports:
             - port: "53"
               protocol: UDP
+            - port: "53"
+              protocol: TCP
           rules:
             dns:
               - matchPattern: "*"

--- a/charts/base-cluster-v2/templates/global/cluster-ingress.yaml
+++ b/charts/base-cluster-v2/templates/global/cluster-ingress.yaml
@@ -10,7 +10,11 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: cluster
-  namespace: {{ .Release.Namespace }}
+  # Co-located with the cluster-wildcard-certificate Secret, which the
+  # cluster-certificate.yaml Certificate creates in the traefik namespace.
+  # Traefik only loads an Ingress TLS Secret from the Ingress's own namespace,
+  # so this must live in traefik, not the chart's release namespace.
+  namespace: traefik
   labels: {{- include "base-cluster.labels" . | nindent 4 }}
 spec:
   ingressClassName: traefik

--- a/charts/base-cluster-v2/templates/ingress/cilium-network-policy.yaml
+++ b/charts/base-cluster-v2/templates/ingress/cilium-network-policy.yaml
@@ -32,6 +32,8 @@ spec:
         - ports:
             - port: "53"
               protocol: UDP
+            - port: "53"
+              protocol: TCP
           rules:
             dns:
               - matchPattern: "*"
@@ -58,6 +60,8 @@ spec:
         - ports:
             - port: "53"
               protocol: UDP
+            - port: "53"
+              protocol: TCP
           rules:
             dns:
               - matchPattern: "*"

--- a/charts/base-cluster-v2/templates/ingress/cilium-network-policy.yaml
+++ b/charts/base-cluster-v2/templates/ingress/cilium-network-policy.yaml
@@ -48,7 +48,12 @@ spec:
     matchLabels:
       app.kubernetes.io/name: external-dns-chart
   egress:
-    - toEntities: [kube-apiserver, world]
+    - toEntities: [kube-apiserver]
+    - toEntities: [world]
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
     - toPorts:
         - ports:
             - port: "53"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Extended DNS query support to include TCP protocol (port 53) in addition to UDP across network policies
  * Added HTTPS traffic support for external DNS operations
  * Improved cert-manager ClusterIssuer solver configuration for better DNS and HTTP validation handling

* **Chores**
  * Helm chart version bumped to 1.0.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->