### PR TITLE
fix(4allportal): make 3d-renderer work under readOnlyRootFilesystem

### DIFF
--- a/charts/4allportal/Chart.yaml
+++ b/charts/4allportal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.10.62"
 description: A Helm chart for 4ALLPORTAL version 3.10.0 and up
 name: 4allportal
-version: 22.0.3
+version: 22.0.4
 icon: https://4allportal.com/wp-content/uploads/2022/07/cropped-4ap_logo.png
 keywords:
   - 4ALLPORTAL

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -406,3 +406,9 @@ This release adds support for referencing an external secret for backup credenti
 When `.Values.backups.volumes.secretName` is set, the chart no longer creates an internal secret from the plain-text values `.Values.backups.volumes.password`, `.Values.backups.target.s3.accessKey`, and `.Values.backups.target.s3.secretKey`. The referenced secret must contain the keys `RESTIC_PASSWORD`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
 
 No action required if you are not using `.Values.backups.volumes.secretName`.
+
+## To 22.0.4
+
+This release makes the 3d-renderer work under a hardened `readOnlyRootFilesystem: true` pod. A writable `emptyDir` is mounted at `/tmp` (hosting the Xvfb socket, the dbus system bus and chromium's user-data-dir) and `HOME` is set to `/tmp`. Without these the pod hung at startup and never became ready on port 8190.
+
+No action required.

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -1,6 +1,6 @@
 # 4allportal
 
-![Version: 22.0.3](https://img.shields.io/badge/Version-22.0.3-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
+![Version: 22.0.4](https://img.shields.io/badge/Version-22.0.4-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
 
 A Helm chart for 4ALLPORTAL version 3.10.0 and up
 

--- a/charts/4allportal/README.md.gotmpl
+++ b/charts/4allportal/README.md.gotmpl
@@ -135,3 +135,9 @@ This release adds support for referencing an external secret for backup credenti
 When `.Values.backups.volumes.secretName` is set, the chart no longer creates an internal secret from the plain-text values `.Values.backups.volumes.password`, `.Values.backups.target.s3.accessKey`, and `.Values.backups.target.s3.secretKey`. The referenced secret must contain the keys `RESTIC_PASSWORD`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
 
 No action required if you are not using `.Values.backups.volumes.secretName`.
+
+## To 22.0.4
+
+This release makes the 3d-renderer work under a hardened `readOnlyRootFilesystem: true` pod. A writable `emptyDir` is mounted at `/tmp` (hosting the Xvfb socket, the dbus system bus and chromium's user-data-dir) and `HOME` is set to `/tmp`. Without these the pod hung at startup and never became ready on port 8190.
+
+No action required.

--- a/charts/4allportal/templates/3d-renderer/deployment.yaml
+++ b/charts/4allportal/templates/3d-renderer/deployment.yaml
@@ -96,7 +96,21 @@ spec:
             - name: config
               mountPath: /4allportal/data
             {{ end }}
-          env: {{- include "4allportal.tracing.jaeger.env" (dict "Chart" .Chart "Release" .Release "Values" .Values "local" .Values.dreiDRenderer.tracing) | nindent 12 }}
+            # Writable scratch required by the renderer image under
+            # readOnlyRootFilesystem: true. startup.sh puts the Xvfb socket
+            # (/tmp/.X11-unix), the dbus system bus (XDG_RUNTIME_DIR=/tmp/run),
+            # and chromium's --user-data-dir all under /tmp, so /tmp must be a
+            # writable emptyDir (the image intentionally avoids /run).
+            - name: tmp
+              mountPath: /tmp
+          env:
+            # HOME must be writable: chromium's crashpad/profile init writes here
+            # at startup and, on the read-only rootfs, the baked /home/chromuser is
+            # not writable -> chromium aborts with SIGTRAP before it ever renders.
+            # Point HOME at the writable /tmp emptyDir mounted above.
+            - name: HOME
+              value: "/tmp"
+            {{- include "4allportal.tracing.jaeger.env" (dict "Chart" .Chart "Release" .Release "Values" .Values "local" .Values.dreiDRenderer.tracing) | nindent 12 }}
           resources: {{- toYaml .Values.dreiDRenderer.resources | nindent 12 }}
       volumes:
         {{ if .Values.global.persistence.useCombinedVolumes }}
@@ -108,6 +122,9 @@ spec:
         - name: config
           {{- include "4allportal.fourallportal.persistence.config.mount" . | nindent 10 }}
         {{ end }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 512Mi
       {{- with .Values.dreiDRenderer.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
The 3d-renderer image (chromium 150 on Xvfb) needs two writable paths that the hardened pod (readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, caps dropped) does not provide, so pods hang at startup and, once past that, chromium crashes before it can render:

- Add a writable emptyDir at /tmp. startup.sh puts the Xvfb socket (/tmp/.X11-unix), the dbus system bus (XDG_RUNTIME_DIR=/tmp/run) and chromium's --user-data-dir under /tmp. Without a writable /tmp the mkdir/ socket writes fail and the pod loops forever on 'until xdpyinfo' -> never serves on 8190 -> readiness fails (0/1). sizeLimit 512Mi: ~4x the ~126MB fixed chromium component footprint measured under load (render output is KB-scale); disk-backed so it costs nothing idle.

- Set HOME=/tmp. The baked /home/chromuser is on the read-only rootfs, so chromium's crashpad/profile init cannot write and the browser aborts with SIGTRAP before any render. Pointing HOME at the writable /tmp emptyDir fixes it.

Verified end-to-end on a live cluster: pod becomes Ready and renders succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D renderer behavior for pods using read-only root filesystems to prevent startup/readiness issues.
* **New Features**
  * Added a writable temporary `/tmp` volume for the renderer and set `HOME` to `/tmp`, with a 512 MiB size limit.
* **Documentation**
  * Updated the Helm chart README upgrade notes for version 22.0.4.
* **Chores**
  * Bumped the Helm chart version to 22.0.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->