### PR TITLE
fix(4allportal): restart samba pod when its configmap changes

### DIFF
--- a/charts/4allportal/Chart.yaml
+++ b/charts/4allportal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.10.62"
 description: A Helm chart for 4ALLPORTAL version 3.10.0 and up
 name: 4allportal
-version: 22.0.4
+version: 22.0.5
 icon: https://4allportal.com/wp-content/uploads/2022/07/cropped-4ap_logo.png
 keywords:
   - 4ALLPORTAL

--- a/charts/4allportal/README.md
+++ b/charts/4allportal/README.md
@@ -1,6 +1,6 @@
 # 4allportal
 
-![Version: 22.0.4](https://img.shields.io/badge/Version-22.0.4-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
+![Version: 22.0.5](https://img.shields.io/badge/Version-22.0.5-informational?style=flat-square) ![AppVersion: 3.10.62](https://img.shields.io/badge/AppVersion-3.10.62-informational?style=flat-square)
 
 A Helm chart for 4ALLPORTAL version 3.10.0 and up
 
@@ -412,3 +412,11 @@ No action required if you are not using `.Values.backups.volumes.secretName`.
 This release makes the 3d-renderer work under a hardened `readOnlyRootFilesystem: true` pod. A writable `emptyDir` is mounted at `/tmp` (hosting the Xvfb socket, the dbus system bus and chromium's user-data-dir) and `HOME` is set to `/tmp`. Without these the pod hung at startup and never became ready on port 8190.
 
 No action required.
+
+## To 22.0.5
+
+This release makes changes to `.Values.samba.mounts` take effect. The samba pod template now carries a `checksum/config` annotation over the samba ConfigMap, so the pod is recreated whenever the generated samba configuration changes.
+
+The samba container imports its configuration into Samba's `net conf` registry **once at container start**, and that registry (in `/var/lib/samba`, an `emptyDir`) is what `smbd` actually serves. Without the annotation the pod was never restarted when the ConfigMap changed, so edits to a share's `users` list silently never reached the running server — a user added to an existing share kept getting access denied until the pod happened to restart for an unrelated reason.
+
+No action required. Note that the upgrade recreates the samba pod, which briefly interrupts active SMB connections.

--- a/charts/4allportal/README.md.gotmpl
+++ b/charts/4allportal/README.md.gotmpl
@@ -141,3 +141,11 @@ No action required if you are not using `.Values.backups.volumes.secretName`.
 This release makes the 3d-renderer work under a hardened `readOnlyRootFilesystem: true` pod. A writable `emptyDir` is mounted at `/tmp` (hosting the Xvfb socket, the dbus system bus and chromium's user-data-dir) and `HOME` is set to `/tmp`. Without these the pod hung at startup and never became ready on port 8190.
 
 No action required.
+
+## To 22.0.5
+
+This release makes changes to `.Values.samba.mounts` take effect. The samba pod template now carries a `checksum/config` annotation over the samba ConfigMap, so the pod is recreated whenever the generated samba configuration changes.
+
+The samba container imports its configuration into Samba's `net conf` registry **once at container start**, and that registry (in `/var/lib/samba`, an `emptyDir`) is what `smbd` actually serves. Without the annotation the pod was never restarted when the ConfigMap changed, so edits to a share's `users` list silently never reached the running server — a user added to an existing share kept getting access denied until the pod happened to restart for an unrelated reason.
+
+No action required. Note that the upgrade recreates the samba pod, which briefly interrupts active SMB connections.

--- a/charts/4allportal/templates/samba/deployment.yaml
+++ b/charts/4allportal/templates/samba/deployment.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels: {{- include "common.labels.stable" $ | nindent 8 }}
         app.kubernetes.io/component: samba
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/samba/configmap.yaml") $ | sha256sum }}
     spec:
       {{- include "4allportal.samba.priorityClassName" $ | nindent 6 }}
       containers:


### PR DESCRIPTION
## Problem

Changes to `.Values.samba.mounts.<path>.users` never reached a running samba pod.

The samba container (sambacc) imports `config.json` into Samba's `net conf` registry **once at container start**. That registry lives in `/var/lib/samba`, which is an `emptyDir`, and it is what `smbd` and `testparm -s` actually serve — not the mounted ConfigMap. Since the samba Deployment had no `checksum/config` annotation, its pod template never changed when the ConfigMap did, so Kubernetes never recreated the pod.



## Fix

Add a `checksum/config` annotation over the samba ConfigMap to the pod template. The Deployment already uses `strategy: Recreate`, so any config change now rolls the pod, which re-imports `config.json` into a fresh registry.

