### PR TITLE
fix(base-cluster-v2): add required missing cilium network policies

### DIFF
--- a/charts/base-cluster-v2/Chart.yaml
+++ b/charts/base-cluster-v2/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   full LGTM observability stack (Grafana, Loki, Mimir, Tempo, and Alloy-based
   metrics/log/trace collection). Successor to the base-cluster chart.
 type: application
-version: 1.4.2
-appVersion: "1.4.2"
+version: 1.4.3
+appVersion: "1.4.3"
 home: https://4allportal.com
 maintainers:
   - name: jpkraemer-mg

--- a/charts/base-cluster-v2/README.md
+++ b/charts/base-cluster-v2/README.md
@@ -1,6 +1,6 @@
 # base-cluster-v2
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.2](https://img.shields.io/badge/AppVersion-1.4.2-informational?style=flat-square)
+![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.3](https://img.shields.io/badge/AppVersion-1.4.3-informational?style=flat-square)
 
 Foundational base cluster setup — Cilium CNI, FluxCD, Traefik ingress,
 cert-manager, ExternalDNS, an internal Librespeed speedtest endpoint, and a

--- a/charts/base-cluster-v2/templates/cert-manager/cilium-network-policy.yaml
+++ b/charts/base-cluster-v2/templates/cert-manager/cilium-network-policy.yaml
@@ -77,4 +77,29 @@ spec:
           rules:
             dns:
               - matchPattern: "*"
+---
+# startupapicheck is a Helm post-install/upgrade HOOK: if it can't reach the apiserver
+# the whole cert-manager release fails. It carries its own name label, so under a
+# default-deny it needs its own egress allow (otherwise: dial 10.5.64.1:443 i/o timeout).
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: cert-manager-startupapicheck
+  namespace: cert-manager
+  labels: {{- include "base-cluster.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cert-manager
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: startupapicheck
+      app.kubernetes.io/instance: cert-manager
+  egress:
+    - toEntities: [kube-apiserver]
+    - toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+          rules:
+            dns:
+              - matchPattern: "*"
 {{- end }}

--- a/charts/base-cluster-v2/templates/global/cilium-network-policy-health.yaml
+++ b/charts/base-cluster-v2/templates/global/cilium-network-policy-health.yaml
@@ -1,0 +1,25 @@
+{{- if eq (include "base-cluster.networkPolicy.type" .) "cilium" }}
+{{/*
+Allow cilium-health connectivity checks under the default-deny. The default-deny
+selects the reserved:health endpoint (it has no namespace label, so a NotIn
+namespace match catches it), so without this the node-to-node health probes
+(remote-node -> health :4240) are Policy-denied and `cilium-health status` reads
+1/N. Verbatim from the Cilium docs (Health Endpoint example). If health still does
+not reach full N/N, add `host` alongside `remote-node`.
+*/}}
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: cilium-health-checks
+  labels: {{- include "base-cluster.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      'reserved:health': ''
+  ingress:
+    - fromEntities:
+        - remote-node
+  egress:
+    - toEntities:
+        - remote-node
+{{- end }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network access for cert-manager startup checks, including Kubernetes API and DNS connectivity.
  * Added Cilium health-check policies to support node-to-node health communication in default-deny environments.

* **Documentation**
  * Updated chart and application version references to 1.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->