### PR TITLE
fix(base-cluster): align 4allportal metrics dashboard with current metric names

### DIFF
--- a/charts/base-cluster/Chart.yaml
+++ b/charts/base-cluster/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A generic, base cluster setup
 name: base-cluster
-version: 41.2.5
+version: 41.2.6
 home: "https://4allportal.com"
 maintainers:
   - name: jpkraemer-mg

--- a/charts/base-cluster/README.md
+++ b/charts/base-cluster/README.md
@@ -1,6 +1,6 @@
 # base-cluster
 
-![Version: 41.2.5](https://img.shields.io/badge/Version-41.2.5-informational?style=flat-square)
+![Version: 41.2.6](https://img.shields.io/badge/Version-41.2.6-informational?style=flat-square)
 
 A generic, base cluster setup
 

--- a/charts/base-cluster/dashboards/4allportal/metrics.json
+++ b/charts/base-cluster/dashboards/4allportal/metrics.json
@@ -65,13 +65,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(m_4allportal_number_of_assets_total{service=\"$4ALLPORTAL-4allportal-backend\"})",
+          "expr": "avg(m_4allportal_number_of_assets{service=\"$4ALLPORTAL-4allportal-backend\"})",
           "hide": false,
           "legendFormat": "Number of assets",
           "refId": "A"
         },
         {
-          "expr": "avg(m_4allportal_number_of_deleted_assets_total{service=\"$4ALLPORTAL-4allportal-backend\"})",
+          "expr": "avg(m_4allportal_number_of_deleted_assets{service=\"$4ALLPORTAL-4allportal-backend\"})",
           "hide": false,
           "legendFormat": "Deleted Assets",
           "refId": "B"
@@ -148,12 +148,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(m_4allportal_active_sessions_total{service=\"$4ALLPORTAL-4allportal-backend\"})",
+          "expr": "max(m_4allportal_active_sessions{service=\"$4ALLPORTAL-4allportal-backend\"})",
           "legendFormat": "Active Sessions",
           "refId": "A"
         },
         {
-          "expr": "max(m_4allportal_active_user_total{service=\"$4ALLPORTAL-4allportal-backend\"})",
+          "expr": "max(m_4allportal_active_user{service=\"$4ALLPORTAL-4allportal-backend\"})",
           "legendFormat": "Unique Users",
           "refId": "B"
         }
@@ -217,7 +217,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "sum(avg(m_4allportal_filetype_total{service=\"$4ALLPORTAL-4allportal-backend\"}) by (FileType,FileTypeCat)) by (FileTypeCat)",
+          "expr": "sum(avg(m_4allportal_filetype{service=\"$4ALLPORTAL-4allportal-backend\"}) by (FileType,FileTypeCat)) by (FileTypeCat)",
           "legendFormat": "{{FileTypeCat}}",
           "refId": "A"
         }
@@ -267,7 +267,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(m_4allportal_number_of_assets_total{service=\"$4ALLPORTAL-4allportal-backend\"}[5m]))",
+          "expr": "avg(m_4allportal_number_of_uploads{service=\"$4ALLPORTAL-4allportal-backend\"})",
           "legendFormat": "Upload",
           "refId": "A"
         }
@@ -289,7 +289,7 @@
       "yaxes": [
         {
           "format": "short",
-          "label": "Uploads / Second",
+          "label": "Uploads / Day",
           "logBase": 1,
           "show": true
         },
@@ -380,7 +380,7 @@
             "uid": "prometheus"
           },
           "exemplar": true,
-          "expr": "max(rate(m_4allportal_requests_total{service=\"$4ALLPORTAL-4allportal-backend\"}[4h]) != 0) by(Status)",
+          "expr": "max(rate(m_4allportal_requests{service=\"$4ALLPORTAL-4allportal-backend\"}[4h]) != 0) by(Status)",
           "interval": "",
           "legendFormat": "{{Status}}",
           "refId": "A"
@@ -418,7 +418,7 @@
       "strokeWidth": 1,
       "targets": [
         {
-          "expr": "avg(m_4allportal_filetype_total{service=\"$4ALLPORTAL-4allportal-backend\"}) by (FileType)",
+          "expr": "avg(m_4allportal_filetype{service=\"$4ALLPORTAL-4allportal-backend\"}) by (FileType)",
           "legendFormat": "{{FileType}}",
           "refId": "A"
         }
@@ -468,7 +468,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(http_server_requests_seconds_max{pod=~\"$4ALLPORTAL-4allportal-backend.*\"}) by (method,pod)",
+          "expr": "max(http_server_requests_duration_seconds_max{pod=~\"$4ALLPORTAL-4allportal-backend.*\"}) by (method,pod)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{pod}}/{{method}}",
@@ -546,7 +546,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "m_4allportal_database_duration_seconds_seconds_max{pod=~\"$4ALLPORTAL-4allportal-backend.*\"}",
+          "expr": "m_4allportal_database_duration_seconds_max{pod=~\"$4ALLPORTAL-4allportal-backend.*\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{pod}}",
@@ -790,7 +790,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(http_server_requests_seconds_count{pod=~\"$4ALLPORTAL-4allportal-backend.*\"}[1m])) by (status, pod)",
+          "expr": "sum(rate(http_server_requests_duration_seconds_count{pod=~\"$4ALLPORTAL-4allportal-backend.*\"}[1m])) by (status, pod)",
           "legendFormat": "{{pod}}: {{status}}",
           "refId": "A"
         }
@@ -1175,113 +1175,6 @@
       "yaxis": {
         "align": false
       }
-    },
-    {
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "align": "auto",
-            "displayMode": "auto"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "dateTimeAsIso"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Age"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "dateTimeFromNow"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 65
-      },
-      "id": 32,
-      "options": {
-        "footer": {
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true
-      },
-      "pluginVersion": "8.3.4",
-      "targets": [
-        {
-          "exemplar": false,
-          "expr": "avg(m_4allportal_4apps_version_timestamp_seconds_total{service=\"$4ALLPORTAL-4allportal-backend\"}) by (App,Version) * 1000",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "4APPs",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true
-            },
-            "indexByName": {},
-            "renameByName": {
-              "Value": "Age"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "App"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
     },
     {
       "collapsed": false,


### PR DESCRIPTION
## Summary

Most panels of the 4allportal metrics dashboard were rendering empty: the backend now exposes
these series as gauges without the `_total` suffix, and Spring's HTTP server timer was renamed to
`http_server_requests_duration_seconds`. All names were verified against a live
`/actuator/prometheus` scrape rather than guessed.

## Renames

| old | new | panel |
|---|---|---|
| `m_4allportal_number_of_assets_total` | `m_4allportal_number_of_assets` | Assets |
| `m_4allportal_number_of_deleted_assets_total` | `m_4allportal_number_of_deleted_assets` | Assets |
| `m_4allportal_active_sessions_total` | `m_4allportal_active_sessions` | Sessions |
| `m_4allportal_active_user_total` | `m_4allportal_active_user` | Sessions |
| `m_4allportal_filetype_total` | `m_4allportal_filetype` | Filetype Categories, Filetypes |
| `m_4allportal_requests_total` | `m_4allportal_requests` | Requests |
| `m_4allportal_database_duration_seconds_seconds_max` | `m_4allportal_database_duration_seconds_max` | Max database response time |
| `http_server_requests_seconds_max` | `http_server_requests_duration_seconds_max` | Max HTTP response time |
| `http_server_requests_seconds_count` | `http_server_requests_duration_seconds_count` | HTTP Requests |

Label names are unchanged (`FileType`, `FileTypeCat`, `Status`, `method`, `status`), and the
`service` / `pod` selectors still match — the service is still named `<fullname>-backend`.

## Beyond renaming

- **Uploads** now reads `m_4allportal_number_of_uploads` instead of `rate(number_of_assets[5m])`.
  The asset count is a gauge that decreases on deletion, which `rate()` would read as a counter
  reset. Y-axis label corrected from "Uploads / Second" to "Uploads / Day".
- **4APPs table removed.** Nothing exposes per-app name and version anymore;
  `m_4allportal_installed_apps` is only a count.
- Chart bumped 41.2.5 → 41.2.6 (the dashboard JSON is globbed into a ConfigMap, so `ct lint`'s
  version-increment check applies), README version badge updated to match.

`alerts.json` needs no change — it only uses `logback_events_total` and cAdvisor metrics, all
still present.

## Follow-ups not included here

- The **Requests** panel still does `rate(m_4allportal_requests[4h])`, which has the same
  gauge-vs-`rate()` problem as Uploads did. Plotting the raw gauge would be more honest, but I
  left the expression alone since it changes what the panel means.
- Several new metrics have no panel yet: `m_4allportal_core_license_valid` /
  `_license_expiry_seconds` (good alert candidates), `m_4allportal_core_slow_queries_total`,
  `m_4allportal_daily_active_user` / `_monthly_active_user`, `m_4allportal_number_of_downloads`,
  `m_4allportal_missing_previews`, and `m_4allportal_core_log_total{class,level,type}`.

## Test plan

- `metrics.json` parses as valid JSON; panel count 31 → 30.
- Every metric name left in the dashboard was checked against the live scrape output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated monitoring dashboards with improved metric queries for assets, sessions, uploads, requests, file types, and response times.
  * Updated the uploads metric label to display uploads per day.
* **Bug Fixes**
  * Removed the outdated “4APPs” dashboard panel.
  * Corrected metrics used for HTTP and database response-time reporting.
* **Chores**
  * Bumped the base-cluster chart version to 41.2.6 and updated its documentation badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->