### PR TITLE
fix(base-cluster-v2): incorrect ingressClassName

### DIFF
--- a/charts/base-cluster-v2/Chart.yaml
+++ b/charts/base-cluster-v2/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   full LGTM observability stack (Grafana, Loki, Mimir, Tempo, and Alloy-based
   metrics/log/trace collection). Successor to the base-cluster chart.
 type: application
-version: 1.4.3
-appVersion: "1.4.3"
+version: 1.4.4
+appVersion: "1.4.4"
 home: https://4allportal.com
 maintainers:
   - name: jpkraemer-mg

--- a/charts/base-cluster-v2/README.md
+++ b/charts/base-cluster-v2/README.md
@@ -1,6 +1,6 @@
 # base-cluster-v2
 
-![Version: 1.4.3](https://img.shields.io/badge/Version-1.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.3](https://img.shields.io/badge/AppVersion-1.4.3-informational?style=flat-square)
+![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
 
 Foundational base cluster setup — Cilium CNI, FluxCD, Traefik ingress,
 cert-manager, ExternalDNS, an internal Librespeed speedtest endpoint, and a

--- a/charts/base-cluster-v2/templates/global/cluster-ingress.yaml
+++ b/charts/base-cluster-v2/templates/global/cluster-ingress.yaml
@@ -13,7 +13,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels: {{- include "base-cluster.labels" . | nindent 4 }}
 spec:
-  ingressClassName: traefik
   rules:
     - host: {{ include "base-cluster.domain" . | quote }}
     - host: {{ printf "*.%s" (include "base-cluster.domain" .) | quote }}

--- a/charts/base-cluster-v2/templates/ingress/speedtest.yaml
+++ b/charts/base-cluster-v2/templates/ingress/speedtest.yaml
@@ -211,7 +211,6 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.middlewares: speedtest-no-compression@file
 spec:
-  ingressClassName: traefik
   tls:
     - hosts:
         - {{ include "base-cluster.speedtest.host" . | quote }}

--- a/charts/base-cluster-v2/templates/monitoring/grafana.yaml
+++ b/charts/base-cluster-v2/templates/monitoring/grafana.yaml
@@ -172,7 +172,6 @@ metadata:
   labels: {{- include "base-cluster.labels" . | nindent 4 }}
     app.kubernetes.io/component: monitoring
 spec:
-  ingressClassName: traefik
   tls:
     - hosts:
         - {{ include "base-cluster.grafana.host" . | quote }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the chart and application version to 1.4.4.
  - Ingress resources now use the cluster’s default ingress class instead of explicitly targeting Traefik.

- **Documentation**
  - Updated the chart version references and badges to 1.4.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->