### PR TITLE
fix(base-cluster-v2): tempo not using defined imagepullsecret

### DIFF
--- a/charts/base-cluster-v2/Chart.yaml
+++ b/charts/base-cluster-v2/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   full LGTM observability stack (Grafana, Loki, Mimir, Tempo, and Alloy-based
   metrics/log/trace collection). Successor to the base-cluster chart.
 type: application
-version: 1.4.4
-appVersion: "1.4.4"
+version: 1.4.5
+appVersion: "1.4.5"
 home: https://4allportal.com
 maintainers:
   - name: jpkraemer-mg

--- a/charts/base-cluster-v2/README.md
+++ b/charts/base-cluster-v2/README.md
@@ -1,6 +1,6 @@
 # base-cluster-v2
 
-![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.4](https://img.shields.io/badge/AppVersion-1.4.4-informational?style=flat-square)
+![Version: 1.4.5](https://img.shields.io/badge/Version-1.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.5](https://img.shields.io/badge/AppVersion-1.4.5-informational?style=flat-square)
 
 Foundational base cluster setup — Cilium CNI, FluxCD, Traefik ingress,
 cert-manager, ExternalDNS, an internal Librespeed speedtest endpoint, and a

--- a/charts/base-cluster-v2/templates/monitoring/tempo.yaml
+++ b/charts/base-cluster-v2/templates/monitoring/tempo.yaml
@@ -30,8 +30,9 @@ spec:
       retries: -1
   values:
     {{- with .Values.global.imagePullSecretName }}
-    imagePullSecrets:
-      - name: {{ . }}
+    serviceAccount:
+      imagePullSecrets:
+        - name: {{ . }}
     {{- end }}
     tempo:
       resources: {{- toYaml .Values.monitoring.tempo.resources | nindent 8 }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the base cluster chart and application release to version 1.4.5.
  * Improved Tempo deployment configuration to apply image pull credentials only when configured.

* **Documentation**
  * Updated the chart’s version badge to reflect release 1.4.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->