### PR TITLE
fix(base-cluster-v2): enforce existingSecret usage for grafana oidc

### DIFF
--- a/charts/base-cluster-v2/Chart.yaml
+++ b/charts/base-cluster-v2/Chart.yaml
@@ -6,8 +6,8 @@ description: |
   full LGTM observability stack (Grafana, Loki, Mimir, Tempo, and Alloy-based
   metrics/log/trace collection). Successor to the base-cluster chart.
 type: application
-version: 1.4.5
-appVersion: "1.4.5"
+version: 1.4.6
+appVersion: "1.4.6"
 home: https://4allportal.com
 maintainers:
   - name: jpkraemer-mg

--- a/charts/base-cluster-v2/README.md
+++ b/charts/base-cluster-v2/README.md
@@ -1,6 +1,6 @@
 # base-cluster-v2
 
-![Version: 1.4.5](https://img.shields.io/badge/Version-1.4.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.5](https://img.shields.io/badge/AppVersion-1.4.5-informational?style=flat-square)
+![Version: 1.4.6](https://img.shields.io/badge/Version-1.4.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.4.6](https://img.shields.io/badge/AppVersion-1.4.6-informational?style=flat-square)
 
 Foundational base cluster setup — Cilium CNI, FluxCD, Traefik ingress,
 cert-manager, ExternalDNS, an internal Librespeed speedtest endpoint, and a
@@ -146,7 +146,6 @@ The older chart remains in this repo for clusters that haven't migrated.
 | monitoring.grafana.oidc.authUrl | string | `""` |  |
 | monitoring.grafana.oidc.autoLogin | bool | `false` |  |
 | monitoring.grafana.oidc.clientAuthentication | string | `""` |  |
-| monitoring.grafana.oidc.clientId | string | `""` |  |
 | monitoring.grafana.oidc.disableLoginForm | bool | `false` |  |
 | monitoring.grafana.oidc.enabled | bool | `false` |  |
 | monitoring.grafana.oidc.existingSecret | string | `""` |  |

--- a/charts/base-cluster-v2/templates/monitoring/grafana.yaml
+++ b/charts/base-cluster-v2/templates/monitoring/grafana.yaml
@@ -139,7 +139,6 @@ spec:
       auth.generic_oauth:
         enabled: true
         name: {{ $g.oidc.name | quote }}
-        client_id: {{ required "monitoring.grafana.oidc.clientId is required when oidc is enabled" $g.oidc.clientId | quote }}
         {{- with $g.oidc.clientAuthentication }}
         client_authentication: {{ . | quote }}
         {{- end }}
@@ -159,9 +158,7 @@ spec:
         oauth_auto_login: {{ $g.oidc.autoLogin }}
         disable_login_form: {{ $g.oidc.disableLoginForm }}
         oauth_allow_insecure_email_lookup: {{ $g.oidc.oauthAllowInsecureEmailLookup }}
-      {{- end }}
-    {{- if and $g.oidc.enabled $g.oidc.existingSecret }}
-    envFromSecret: {{ $g.oidc.existingSecret | quote }}
+    envFromSecret: {{ required "monitoring.grafana.oidc.existingSecret is required when oidc is enabled" $g.oidc.existingSecret | quote }}
     {{- end }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/charts/base-cluster-v2/values.yaml
+++ b/charts/base-cluster-v2/values.yaml
@@ -314,15 +314,14 @@ monitoring:
     existingAdminSecret: ""
     ## OIDC SSO via Grafana's generic_oauth provider.
     ## Renders the [auth.generic_oauth] + [auth] sections of grafana.ini.
-    ## When enabled, set clientId + endpoint URLs and supply the client secret
-    ## via `existingSecret` (env var GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET, picked
-    ## up automatically — Grafana's env override).
+    ## When enabled, set endpoint URLs and supply the client secret via `existingSecret`
+    ## (env vars GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET and GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+    ## picked up automatically — Grafana's env override).
     oidc:
       enabled: false
       ## Label shown on the Grafana login page.
       name: SSO
-      clientId: ""
-      ## Secret with `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` key (envFrom).
+      ## Secret with `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` and `GF_AUTH_GENERIC_OAUTH_CLIENT_ID` keys (envFrom).
       existingSecret: ""
       ## Client auth method. Empty = Grafana default (`client_secret_basic`).
       ## Entra ID requires `client_secret_post`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the base cluster chart and application version to 1.4.6.
  * Improved Grafana OIDC configuration by sourcing both client ID and client secret from an existing secret.

* **Documentation**
  * Updated chart documentation and configuration guidance for the new Grafana OIDC secret requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->